### PR TITLE
Add endpoint to fetch top articles with favorites count

### DIFF
--- a/src/app/routes/article/article.controller.ts
+++ b/src/app/routes/article/article.controller.ts
@@ -10,11 +10,31 @@ import {
   getArticles,
   getCommentsByArticle,
   getFeed,
+  getTopArticles,
   unfavoriteArticle,
   updateArticle,
 } from './article.service';
 
 const router = Router();
+
+/**
+ * Get top 3 articles by favorites count
+ * @auth optional
+ * @route {GET} /articles/top
+ * @returns top articles with slug, title, and favorites count
+ */
+router.get(
+  '/articles/top',
+  auth.optional,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const topArticles = await getTopArticles();
+      res.json({ topArticles });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
 
 /**
  * Get paginated articles
@@ -27,14 +47,18 @@ const router = Router();
  * @queryparam favorited
  * @returns articles: list of articles
  */
-router.get('/articles', auth.optional, async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const result = await getArticles(req.query, req.auth?.user?.id);
-    res.json(result);
-  } catch (error) {
-    next(error);
+router.get(
+  '/articles',
+  auth.optional,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const result = await getArticles(req.query, req.auth?.user?.id);
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
   }
-});
+);
 
 /**
  * Get paginated feed articles
@@ -50,13 +74,13 @@ router.get(
       const result = await getFeed(
         Number(req.query.offset),
         Number(req.query.limit),
-        req.auth?.user?.id,
+        req.auth?.user?.id
       );
       res.json(result);
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -68,14 +92,18 @@ router.get(
  * @bodyparam  tagList list of tags
  * @returns article created article
  */
-router.post('/articles', auth.required, async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const article = await createArticle(req.body.article, req.auth?.user?.id);
-    res.status(201).json({ article });
-  } catch (error) {
-    next(error);
+router.post(
+  '/articles',
+  auth.required,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const article = await createArticle(req.body.article, req.auth?.user?.id);
+      res.status(201).json({ article });
+    } catch (error) {
+      next(error);
+    }
   }
-});
+);
 
 /**
  * Get unique article
@@ -94,7 +122,7 @@ router.get(
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -112,12 +140,16 @@ router.put(
   auth.required,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const article = await updateArticle(req.body.article, req.params.slug, req.auth?.user?.id);
+      const article = await updateArticle(
+        req.body.article,
+        req.params.slug,
+        req.auth?.user?.id
+      );
       res.json({ article });
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -136,7 +168,7 @@ router.delete(
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -151,12 +183,15 @@ router.get(
   auth.optional,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const comments = await getCommentsByArticle(req.params.slug, req.auth?.user?.id);
+      const comments = await getCommentsByArticle(
+        req.params.slug,
+        req.auth?.user?.id
+      );
       res.json({ comments });
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -172,12 +207,16 @@ router.post(
   auth.required,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const comment = await addComment(req.body.comment.body, req.params.slug, req.auth?.user?.id);
+      const comment = await addComment(
+        req.body.comment.body,
+        req.params.slug,
+        req.auth?.user?.id
+      );
       res.json({ comment });
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -197,7 +236,7 @@ router.delete(
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -212,12 +251,15 @@ router.post(
   auth.required,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const article = await favoriteArticle(req.params.slug, req.auth?.user?.id);
+      const article = await favoriteArticle(
+        req.params.slug,
+        req.auth?.user?.id
+      );
       res.json({ article });
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 /**
@@ -232,12 +274,15 @@ router.delete(
   auth.required,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const article = await unfavoriteArticle(req.params.slug, req.auth?.user?.id);
+      const article = await unfavoriteArticle(
+        req.params.slug,
+        req.auth?.user?.id
+      );
       res.json({ article });
     } catch (error) {
       next(error);
     }
-  },
+  }
 );
 
 export default router;

--- a/src/app/routes/article/article.service.ts
+++ b/src/app/routes/article/article.service.ts
@@ -168,7 +168,9 @@ export const createArticle = async (article: any, id: number) => {
   }
 
   if (!description) {
-    throw new HttpException(422, { errors: { description: ["can't be blank"] } });
+    throw new HttpException(422, {
+      errors: { description: ["can't be blank"] },
+    });
   }
 
   if (!body) {
@@ -463,7 +465,9 @@ export const getCommentsByArticle = async (slug: string, id?: number) => {
       username: comment.author.username,
       bio: comment.author.bio,
       image: comment.author.image,
-      following: comment.author.followedBy.some((follow: any) => follow.id === id),
+      following: comment.author.followedBy.some(
+        (follow: any) => follow.id === id
+      ),
     },
   }));
 
@@ -519,7 +523,9 @@ export const addComment = async (body: string, slug: string, id: number) => {
       username: comment.author.username,
       bio: comment.author.bio,
       image: comment.author.image,
-      following: comment.author.followedBy.some((follow: any) => follow.id === id),
+      following: comment.author.followedBy.some(
+        (follow: any) => follow.id === id
+      ),
     },
   };
 };
@@ -598,7 +604,9 @@ export const favoriteArticle = async (slugPayload: string, id: number) => {
     ...article,
     author: profileMapper(article.author, id),
     tagList: article?.tagList.map((tag: Tag) => tag.name),
-    favorited: article.favoritedBy.some((favorited: any) => favorited.id === id),
+    favorited: article.favoritedBy.some(
+      (favorited: any) => favorited.id === id
+    ),
     favoritesCount: _count?.favoritedBy,
   };
 
@@ -644,9 +652,36 @@ export const unfavoriteArticle = async (slugPayload: string, id: number) => {
     ...article,
     author: profileMapper(article.author, id),
     tagList: article?.tagList.map((tag: Tag) => tag.name),
-    favorited: article.favoritedBy.some((favorited: any) => favorited.id === id),
+    favorited: article.favoritedBy.some(
+      (favorited: any) => favorited.id === id
+    ),
     favoritesCount: _count?.favoritedBy,
   };
 
   return result;
+};
+export const getTopArticles = async () => {
+  const topArticles = await prisma.article.findMany({
+    orderBy: {
+      favoritedBy: {
+        _count: 'desc',
+      },
+    },
+    take: 3, // Solo los 3 más populares
+    select: {
+      slug: true,
+      title: true,
+      _count: {
+        select: {
+          favoritedBy: true,
+        },
+      },
+    },
+  });
+
+  return topArticles.map((article) => ({
+    slug: article.slug,
+    title: article.title,
+    favoritesCount: article._count.favoritedBy,
+  }));
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ app.use(
     err: Error | HttpException,
     req: express.Request,
     res: express.Response,
-    next: express.NextFunction,
+    next: express.NextFunction
   ) => {
     // @ts-ignore
     if (err && err.name === 'UnauthorizedError') {
@@ -43,7 +43,7 @@ app.use(
     } else if (err) {
       res.status(500).json(err.message);
     }
-  },
+  }
 );
 
 /**


### PR DESCRIPTION
**Add /articles/top Endpoint to Get Top Articles**

**Summary:**
This PR adds a new endpoint `/articles/top` that returns the top 3 most favorited articles. Each article includes its slug, title, and the count of favorites.

**Changes Made:**
- Added the `getTopArticles` function to fetch the top 3 articles based on favorites count.
- Created the `GET /articles/top` endpoint in the controller.

**How to Test:**
1. Send a `GET` request to `/api/articles/top`.
2. Check that the response includes `slug`, `title`, and `favoritesCount` for the top 3 articles.
